### PR TITLE
Add error boundary and dev error listeners for routes

### DIFF
--- a/src/app/bootstrapDevErrorHooks.js
+++ b/src/app/bootstrapDevErrorHooks.js
@@ -1,0 +1,7 @@
+window.addEventListener('error', (e) => {
+  console.error('[window error]', e.error || e.message || e);
+});
+
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('[unhandledrejection]', e.reason || e);
+});

--- a/src/app/components/ErrorBoundary.jsx
+++ b/src/app/components/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('[ErrorBoundary] Caught error:', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 24 }}>
+          <h2>Something went wrong.</h2>
+          <pre style={{ whiteSpace: 'pre-wrap' }}>
+            {String(this.state.error?.message || this.state.error)}
+          </pre>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/app/contexts/ProtectedRoute.jsx
+++ b/src/app/contexts/ProtectedRoute.jsx
@@ -1,26 +1,15 @@
-// ProtectedRoute.jsx
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
-import SpinnerOverlay from '../../components/SpinnerOverlay';
 
-const ProtectedRoute = ({ children }) => {
-  const { isAuthenticated, loading } = useAuth();
+export default function ProtectedRoute({ children }) {
+  const { loading, authStatus } = useAuth();
 
-  // Show loading state while authentication is being validated
-  if (loading) {
-    return (
-      <div style={{ 
-        position: 'relative',
-        height: '100vh',
-        width: '100vw'
-      }}>
-        <SpinnerOverlay />
-      </div>
-    );
+  if (loading) return <div style={{ padding: 24 }}>Checking session…</div>;
+
+  if (authStatus !== 'signedIn' && authStatus !== 'incompleteProfile') {
+    return <Navigate to="/login" replace />;
   }
 
-  return isAuthenticated ? children : <Navigate to="/login" />;
-};
-
-export default ProtectedRoute;
+  return children;
+}

--- a/src/app/routes.jsx
+++ b/src/app/routes.jsx
@@ -14,6 +14,7 @@ import {
   NavigationDirectionProvider,
 } from "./contexts/NavigationDirectionProvider";
 import ProtectedRoute from "./contexts/ProtectedRoute";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useData } from "../app/contexts/DataProvider";
 import NotFound from "../components/notfound";
 import TermsAndPrivacy from "../pages/TermsAndPrivacy/TermsAndPrivacy";
@@ -88,10 +89,14 @@ function AppRoutes() {
   const location = useLocation();
 
   return (
-    <NavigationDirectionProvider>
-      <ScrollToTop />
-      <ActualRoutes location={location} />
-    </NavigationDirectionProvider>
+    <ErrorBoundary>
+      <Suspense fallback={<div style={{ padding: 24 }}>Loading…</div>}>
+        <NavigationDirectionProvider>
+          <ScrollToTop />
+          <ActualRoutes location={location} />
+        </NavigationDirectionProvider>
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,10 @@ import App from './app/App';
 import 'antd/dist/reset.css';
 import './index.css';
 
+if (import.meta.env.DEV) {
+  import('./app/bootstrapDevErrorHooks');
+}
+
 // ✅ Amplify config
 Amplify.configure(awsConfig);
 


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary and bootstrap dev error hooks for catching lazy load issues
- wrap routes with ErrorBoundary and Suspense to surface lazy module errors
- refine ProtectedRoute logic to wait for auth and ensure proper redirect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3e0524f6c8324a6174ce372bfbb20