### PR TITLE
Refine project header layout for mobile

### DIFF
--- a/src/components/AvatarStack.js
+++ b/src/components/AvatarStack.js
@@ -2,8 +2,6 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import React, { useEffect, useState } from 'react';
 import styles from './AvatarStack.module.css';
 const getMaxVisible = () => {
-    if (window.innerWidth < 480)
-        return 2;
     if (window.innerWidth < 768)
         return 3;
     return 4;

--- a/src/pages/dashboard/components/SingleProject/ProjectHeader.css
+++ b/src/pages/dashboard/components/SingleProject/ProjectHeader.css
@@ -1,9 +1,17 @@
+
+.single-project-title {
+  min-width: 0;
+}
+
 .single-project-title .project-title-heading {
-  font-size: clamp(1.5rem, 2vw + 1rem, 2.5rem);
+  font-size: clamp(10px, 2.2vw, 16px);
   font-weight: 600;
   margin: 0;
   line-height: 1.1;
-  word-break: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .project-logo {
@@ -32,6 +40,21 @@
 }
 
 
+.date-pills {
+  display: flex;
+  gap: 4px;
+  margin-left: 4px;
+}
+
+.date-pills .pill {
+  background: #1a1a1a;
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: clamp(8px, 1.8vw, 12px);
+  white-space: nowrap;
+}
+
 @media (max-width: 600px) {
   .status-svg {
     width: clamp(32px, 10vw, 44px) !important;
@@ -41,17 +64,8 @@
     max-width: 44px !important;
     max-height: 44px !important;
   }
-}
-
-@media (max-width: 600px) {
   .project-logo {
     width: clamp(40px, 15vw, 44px);
     height: clamp(40px, 15vw, 44px);
-  }
-}
-
-@media (max-width: 600px) {
-  .single-project-title .project-title-heading {
-    font-size: clamp(1.1rem, 5vw, 1.7rem);
   }
 }

--- a/src/pages/dashboard/style.css
+++ b/src/pages/dashboard/style.css
@@ -729,20 +729,35 @@ body.ReactModal__Body--open .dashboard-wrapper {
 
 .project-header .header-content {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
   width: 100%;
   max-width: 100%;
   padding: 0px 5px 5px;
   box-sizing: border-box;
-  
   overflow: hidden;
+}
+
+.project-header .header-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  width: 100%;
 }
 
 .project-header .left-side,
 .project-header .right-side {
   display: flex;
   align-items: center;
+  gap: 6px;
+}
+
+.project-header .right-side {
+  margin-left: auto;
+}
+
+.project-header .left-side {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .project-header .left-side svg {
@@ -750,7 +765,6 @@ body.ReactModal__Body--open .dashboard-wrapper {
   /* Larger width */
   height: auto;
   flex-shrink: 0;
-  margin: 0 5px;
 }
 
 /* Reduce cogwheel icon width to match right-side icons */
@@ -850,7 +864,6 @@ body.ReactModal__Body--open .dashboard-wrapper {
 
 .project-header h2 {
   line-height: 0.8;
-  font-size: min(4rem, 5vw);
 }
 .project-header svg {
   width: 100px;


### PR DESCRIPTION
## Summary
- Limit visible avatars in header to three with overflow counter
- Shrink project title and add ellipsis styling with compact date pills
- Reorganize project header layout for tighter mobile presentation

## Testing
- `npm test`
- `npm run lint` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6363b9804832494d675039bcb6996