### PR TITLE
chore: import React for classic jsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import mylgLogo from './assets/svg/logo.svg'
 import reactLogo from './assets/react.svg'
 import './App.css'

--- a/src/app/contexts/AuthEventHandler.tsx
+++ b/src/app/contexts/AuthEventHandler.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Hub } from 'aws-amplify/utils';
 import { useAuth } from './AuthContext';

--- a/src/components/LexicalEditor/plugins/ColorPlugin.jsx
+++ b/src/components/LexicalEditor/plugins/ColorPlugin.jsx
@@ -1,5 +1,5 @@
+import React, { useEffect, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { useEffect, useState } from "react";
 import {
   $getSelection,
   $isRangeSelection,

--- a/src/components/LexicalEditor/plugins/DragAndDropPlugin.jsx
+++ b/src/components/LexicalEditor/plugins/DragAndDropPlugin.jsx
@@ -1,5 +1,4 @@
-
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $createResizableImageNode } from "./nodes/ResizableImageNode";
 import { $insertNodes, $createTextNode, $getSelection, $isRangeSelection } from "lexical";

--- a/src/components/LexicalEditor/plugins/FontPlugin.jsx
+++ b/src/components/LexicalEditor/plugins/FontPlugin.jsx
@@ -1,5 +1,5 @@
+import React, { useEffect, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { useEffect, useState } from "react";
 import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_EDITOR } from "lexical";
 import { $patchStyleText } from "@lexical/selection";
 import { SET_FONT_FAMILY_COMMAND, SET_FONT_SIZE_COMMAND } from "../commands";

--- a/src/components/LexicalEditor/plugins/LayoutPlugin.jsx
+++ b/src/components/LexicalEditor/plugins/LayoutPlugin.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { ReactComponent as LayoutIcon } from '../images/icons/columns.svg';
 

--- a/src/components/WebSocketDiagnostic.tsx
+++ b/src/components/WebSocketDiagnostic.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const WebSocketDiagnostic: React.FC = () => {
+  return null;
+};
+
+export default WebSocketDiagnostic;
+

--- a/src/pages/dashboard/components/SingleProject/Dropdown.tsx
+++ b/src/pages/dashboard/components/SingleProject/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FC } from 'react';
+import React, { useEffect, useRef, useState, type FC } from 'react';
 import styles from './FileManager.module.css';
 
 interface Option {

--- a/src/pages/dashboard/components/Welcome/TopBar.tsx
+++ b/src/pages/dashboard/components/Welcome/TopBar.tsx
@@ -1,5 +1,5 @@
+import React, { useEffect, useState, type FC } from 'react';
 import { Briefcase, Calendar } from 'lucide-react';
-import { useEffect, useState, type FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useData, type Project } from '../../../../app/contexts/DataProvider';

--- a/src/pages/gallery/GalleryMasonry.tsx
+++ b/src/pages/gallery/GalleryMasonry.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import React, { type FC } from 'react';
 
 import styles from './GalleryMasonry.module.css';
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,7 +14,7 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
       "resolveJsonModule": true,
 
     /* Linting */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "strict": false,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## Summary
- use classic JSX runtime in TypeScript configs
- import React explicitly across components and plugins
- stub WebSocket diagnostic component

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8ac8017c8324994d474ed72f21da