### PR TITLE
Limit budget refresh to relevant WebSocket events

### DIFF
--- a/src/pages/dashboard/components/SingleProject/BudgetComponent.tsx
+++ b/src/pages/dashboard/components/SingleProject/BudgetComponent.tsx
@@ -78,6 +78,9 @@ const BudgetComponent: React.FC<BudgetComponentProps> = ({ activeProject }) => {
         const data = typeof event.data === "string" ? JSON.parse(event.data) : event.data;
         if (data?.action === "budgetUpdated" && data.projectId === activeProject?.projectId) {
           refresh();
+        } else {
+          // Log other messages for debugging but skip refresh
+          console.log("[BudgetComponent] Ignoring websocket message", data);
         }
       } catch {
         // Ignore parse errors
@@ -183,7 +186,6 @@ const BudgetComponent: React.FC<BudgetComponentProps> = ({ activeProject }) => {
         setIsInvoicePreviewOpen(true);
       }
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.error("Failed to load invoice", err);
     }
   };


### PR DESCRIPTION
## Summary
- Only refresh budget data when `budgetUpdated` messages target the active project and log any other WebSocket events
- Centralize budget reloading in `BudgetPage` via a `refresh` helper and ignore unrelated WebSocket messages
- Avoid unnecessary state updates in `useBudgetData` through shallow equality checks

## Testing
- `npm test`
- `npx eslint src/pages/dashboard/BudgetPage.tsx src/pages/dashboard/components/SingleProject/BudgetComponent.tsx src/pages/dashboard/components/SingleProject/useBudgetData.ts` *(fails: existing lint errors in BudgetPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8a9766208324a47b4029ab445800