### PR TITLE
feat: isolate budget websocket updates

### DIFF
--- a/src/utils/channelStore.js
+++ b/src/utils/channelStore.js
@@ -1,0 +1,55 @@
+import { useSyncExternalStore } from "react";
+
+// Map to hold latest values by channel key
+const channels = new Map();
+// Map of channel listeners
+const listeners = new Map();
+
+function get(key, fallback) {
+  return channels.has(key) ? channels.get(key) : fallback;
+}
+
+function subscribe(key, fn) {
+  let set = listeners.get(key);
+  if (!set) {
+    set = new Set();
+    listeners.set(key, set);
+  }
+  set.add(fn);
+  return () => {
+    set.delete(fn);
+    if (set.size === 0) {
+      listeners.delete(key);
+    }
+  };
+}
+
+function notify(key) {
+  const set = listeners.get(key);
+  if (set) {
+    for (const fn of set) {
+      try {
+        fn();
+      } catch (err) {
+        // ignore individual listener errors
+        console.error(err);
+      }
+    }
+  }
+}
+
+export const channelStore = {
+  channels,
+  get,
+  subscribe,
+  notify,
+};
+
+export function useChannel(key, fallback) {
+  return useSyncExternalStore(
+    (fn) => channelStore.subscribe(key, fn),
+    () => channelStore.get(key, fallback),
+    () => channelStore.get(key, fallback)
+  );
+}
+


### PR DESCRIPTION
## Summary
- add channelStore and useChannel hook to expose channel-based updates
- route budget websocket events through channelStore
- subscribe BudgetComponent and BudgetPage to project-specific budget channel

## Testing
- `npm test`
- `npm run lint` *(fails: `@typescript-eslint/no-unused-vars`, `@typescript-eslint/no-explicit-any`, `no-empty`)*

------
https://chatgpt.com/codex/tasks/task_e_68aac197d5a883249c6863a4e274418a