### PR TITLE
Fix array payload handling in request queue

### DIFF
--- a/src/app/contexts/DataProvider.tsx
+++ b/src/app/contexts/DataProvider.tsx
@@ -50,6 +50,8 @@ export interface TimelineEvent {
   title?: string;
   date?: string;        // ISO string
   timestamp?: string;   // ISO string
+  hours?: number | string;
+  budgetItemId?: string | null;
   [k: string]: unknown;
 }
 

--- a/src/pages/dashboard/BudgetPage.tsx
+++ b/src/pages/dashboard/BudgetPage.tsx
@@ -31,7 +31,7 @@ import EventEditModal from "./components/SingleProject/EventEditModal";
 import RevisionModal from "./components/SingleProject/RevisionModal";
 import BudgetChart from "./components/SingleProject/BudgetChart";
 import BudgetToolbar from "./components/SingleProject/BudgetToolbar";
-import { useData } from "../../app/contexts/DataProvider";
+import { useData, TimelineEvent } from "../../app/contexts/DataProvider";
 import { useSocket } from "../../app/contexts/SocketContext";
 import { normalizeMessage } from "../../utils/websocketUtils";
 import { findProjectBySlug, slugify } from "../../utils/slug";
@@ -179,11 +179,15 @@ const BudgetPage = () => {
     }
   };
 
-  const queueEventsUpdate = async (events) => {
+  const queueEventsUpdate = async (events: TimelineEvent[]) => {
     if (!activeProject?.projectId) return;
     try {
       setSaving(true);
-      await enqueueProjectUpdate(updateTimelineEvents, activeProject.projectId, events);
+      await enqueueProjectUpdate(
+        (id, { events: evts }) => updateTimelineEvents(id, evts),
+        activeProject.projectId,
+        { events }
+      );
     } finally {
       setSaving(false);
     }

--- a/src/pages/dashboard/components/SingleProject/ProjectCalendar.tsx
+++ b/src/pages/dashboard/components/SingleProject/ProjectCalendar.tsx
@@ -227,7 +227,11 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
     if (!project?.projectId) return;
     try {
       setSaving(true);
-      await enqueueProjectUpdate(updateTimelineEvents, project.projectId, evts);
+      await enqueueProjectUpdate(
+        (id, { events }) => updateTimelineEvents(id, events),
+        project.projectId,
+        { events: evts }
+      );
     } finally {
       setSaving(false);
     }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -51,6 +51,8 @@ export interface TimelineEvent extends JsonRecord {
   date?: string; // ISO YYYY-MM-DD
   description?: string;
   createdAt?: string;
+  hours?: number | string;
+  budgetItemId?: string | null;
   payload?: { description?: string } & JsonRecord;
 }
 


### PR DESCRIPTION
## Summary
- Preserve array payloads in request queue by avoiding object spread and widening payload types
- Wrap timeline event updates when enqueuing in Budget and ProjectCalendar pages
- Add `hours` and `budgetItemId` fields to `TimelineEvent` type definitions

## Testing
- `npm test`
- `npm run lint` *(fails: 716 problems, 573 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aacd7de76483248f475872c4df0d54