### PR TITLE
feat: centralize budget data with provider

### DIFF
--- a/src/pages/dashboard/BudgetPage.tsx
+++ b/src/pages/dashboard/BudgetPage.tsx
@@ -31,6 +31,7 @@ import EventEditModal from "./components/SingleProject/EventEditModal";
 import RevisionModal from "./components/SingleProject/RevisionModal";
 import BudgetChart from "./components/SingleProject/BudgetChart";
 import BudgetToolbar from "./components/SingleProject/BudgetToolbar";
+import BudgetItemsTable from "./components/SingleProject/BudgetItemsTable";
 import { useData } from "../../app/contexts/DataProvider";
 import { useSocket } from "../../app/contexts/SocketContext";
 import { normalizeMessage } from "../../utils/websocketUtils";
@@ -1669,90 +1670,33 @@ const BudgetPage = () => {
               handleRedo={handleRedo}
               openCreateModal={openCreateModal}
             />
-            <div ref={tableRef} style={{ width: "100%", fontSize: '10px' }}>
-              <Table
-                dataSource={budgetItems.length > 0 ? groupedTableData : []}
-                columns={tableColumns.map((col) => ({
-                  ...col,
-                  ellipsis: col.key !== 'actions' && col.key !== 'events',
-                }))}
-                    locale={{
-                  emptyText: (
-                    <div className={styles.emptyPlaceholder}>
-                      No budget items to display
-                    </div>
-                  ),
-                }}
-
-                onChange={handleTableChange}
-                rowClassName={(record) =>
-                  `${styles.clickableRow}${
-                    selectedRowKeys.includes(record.budgetItemId)
-                      ? ` ${styles.selectedRow}`
-                      : ''
-                  }${
-                    lockedLines.includes(record.budgetItemId)
-                      ? ` ${styles.lockedRow}`
-                      : ''
-                  }`}
-                onRow={(record) => ({
-                  onClick: () => openEditModal(record),
-                  tabIndex: lockedLines.includes(record.budgetItemId) ? -1 : 0,
-                  onKeyDown: (e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      openEditModal(record);
-                    } else if (e.key === ' ') {
-                      e.preventDefault();
-                      openDeleteModal([record.budgetItemId]);
-                    }
-                  },
-                })}
-                expandable={
-                  budgetItems.length > 0
-                    ? {
-                        expandedRowRender,
-                        // Show the expand icon on the rightmost side of the table
-                        expandIconColumnIndex: tableColumns.length,
-                        expandedRowOffset: groupBy === "none" ? 1 : 2,
-                        expandedRowKeys,
-                        onExpand: (expanded, record) => {
-                          setExpandedRowKeys((prev) =>
-                            expanded
-                              ? [...prev, record.key]
-                              : prev.filter((k) => k !== record.key)
-                          );
-                        },
-                      }
-                    : undefined
-                }
-                pagination={{
-                  pageSize,
-                  current: currentPage,
-                  showSizeChanger: true,
-                  pageSizeOptions: ['10', '20', '50', '100'],
-                  position: ['bottomRight'],
-                  showTotal: (total, range) =>
-                    `Showing ${range[0]}–${range[1]} of ${total} items`,
-                  size: 'small',
-                  onChange: (page, size) => {
-                    setCurrentPage(page);
-                    if (size !== pageSize) setPageSize(size);
-                  },
-                }}
-                scroll={{ y: Math.max(0, tableHeight - TABLE_HEADER_FOOTER) }}
-                className={styles.tableMinHeight}
-                style={{ height: tableHeight }}
-              />
-            </div>
+            <BudgetItemsTable
+              dataSource={budgetItems.length > 0 ? groupedTableData : []}
+              columns={tableColumns}
+              groupBy={groupBy}
+              selectedRowKeys={selectedRowKeys}
+              lockedLines={lockedLines}
+              handleTableChange={handleTableChange}
+              openEditModal={openEditModal}
+              openDeleteModal={openDeleteModal}
+              expandedRowRender={expandedRowRender}
+              expandedRowKeys={expandedRowKeys}
+              setExpandedRowKeys={setExpandedRowKeys}
+              tableRef={tableRef}
+              tableHeight={tableHeight}
+              pageSize={pageSize}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              setPageSize={setPageSize}
+            />
           </div>
         </div>
       </div>
-      </div>
-      </motion.div>
-    </AnimatePresence>
-  </ProjectPageLayout>
-  </>
+    </div>
+    </motion.div>
+  </AnimatePresence>
+</ProjectPageLayout>
+</>
   );
 };
 

--- a/src/pages/dashboard/SingleProject.tsx
+++ b/src/pages/dashboard/SingleProject.tsx
@@ -9,6 +9,7 @@ import QuickLinksComponent from "./components/SingleProject/QuickLinksComponent"
 import LocationComponent from "./components/SingleProject/LocationComponent";
 import FileManagerComponent from "./components/SingleProject/FileManager";
 import TasksComponent from "./components/SingleProject/TasksComponent";
+import { BudgetProvider } from "./components/SingleProject/BudgetDataProvider";
 import { useData } from "../../app/contexts/DataProvider";
 import { useSocket } from "../../app/contexts/SocketContext";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -185,8 +186,9 @@ const SingleProject: React.FC = () => {
           exit={{ x: -100, opacity: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="overview-layout">
-            <QuickLinksComponent ref={quickLinksRef} {...({ hideTrigger: true } as any)} />
+          <BudgetProvider projectId={activeProject?.projectId}>
+            <div className="overview-layout">
+              <QuickLinksComponent ref={quickLinksRef} {...({ hideTrigger: true } as any)} />
 
             {(FileManagerComponent as any) && (
               <FileManagerComponent
@@ -199,45 +201,46 @@ const SingleProject: React.FC = () => {
               />
             )}
 
-            <div className="dashboard-layout budget-calendar-layout">
-              <div className="budget-column">
-                <BudgetComponent projectId={activeProject?.projectId} />
+              <div className="dashboard-layout budget-calendar-layout">
+                <div className="budget-column">
+                  <BudgetComponent projectId={activeProject?.projectId} />
 
-                <GalleryComponent />
+                  <GalleryComponent />
+                </div>
+                <div className="calendar-column">
+                  <ProjectCalendar
+                    project={activeProject}
+                    initialFlashDate={flashDate}
+                    showEventList={false}
+                    onWrapperClick={openCalendarPage}
+                    onDateSelect={noop}
+                  />
+                </div>
               </div>
-              <div className="calendar-column">
-                <ProjectCalendar
-                  project={activeProject}
-                  initialFlashDate={flashDate}
-                  showEventList={false}
-                  onWrapperClick={openCalendarPage}
-                  onDateSelect={noop}
-                />
+
+              <Timeline
+                activeProject={activeProject}
+                parseStatusToNumber={parseStatusToNumber}
+                onActiveProjectChange={handleActiveProjectChange}
+              />
+
+              <div className="dashboard-layout timeline-location-row">
+                <div className="location-wrapper">
+                  <LocationComponent
+                    activeProject={activeProject}
+                    onActiveProjectChange={handleActiveProjectChange}
+                  />
+                </div>
+                <div className="tasks-wrapper">
+                  <TasksComponent
+                    projectId={activeProject?.projectId}
+                    userId={userId}
+                    team={activeProject?.team}
+                  />
+                </div>
               </div>
             </div>
-
-            <Timeline
-              activeProject={activeProject}
-              parseStatusToNumber={parseStatusToNumber}
-              onActiveProjectChange={handleActiveProjectChange}
-            />
-
-            <div className="dashboard-layout timeline-location-row">
-              <div className="location-wrapper">
-                <LocationComponent
-                  activeProject={activeProject}
-                  onActiveProjectChange={handleActiveProjectChange}
-                />
-              </div>
-              <div className="tasks-wrapper">
-                <TasksComponent
-                  projectId={activeProject?.projectId}
-                  userId={userId}
-                  team={activeProject?.team}
-                />
-              </div>
-            </div>
-          </div>
+          </BudgetProvider>
         </motion.div>
       </AnimatePresence>
     </ProjectPageLayout>

--- a/src/pages/dashboard/components/SingleProject/BudgetComponent.tsx
+++ b/src/pages/dashboard/components/SingleProject/BudgetComponent.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
-import { useSocketEvents } from "../../../../app/contexts/SocketContext";
+import React, { useState, useMemo, useCallback } from "react";
 
 import { CircleDollarSign } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -9,7 +8,7 @@ import { slugify } from "../../../../utils/slug";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFileInvoiceDollar, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import ClientInvoicePreviewModal from "./ClientInvoicePreviewModal";
-import useBudgetData from "./useBudgetData";
+import { useBudget } from "./BudgetDataProvider";
 import VisxPieChart from "./VisxPieChart";
 import { generateSequentialPalette, getColor } from "../../../../utils/colorUtils";
 
@@ -44,43 +43,10 @@ interface BudgetComponentProps {
 }
 
 const BudgetComponent: React.FC<BudgetComponentProps> = ({ projectId }) => {
-   const { activeProject, isAdmin } = useData(); 
+  const { activeProject, isAdmin } = useData();
   console.log("[BudgetComponent] render");
-  const { budgetHeader, budgetItems, refresh, loading } = useBudgetData(
-    projectId
-  ) as {
-    budgetHeader?: BudgetHeader | null;
-    budgetItems: BudgetItem[];
-    refresh: () => Promise<{ header?: BudgetHeader } | void>;
-    loading: boolean;
-  };
-
-  const onSocketEvent = useSocketEvents();
+  const { budgetHeader, budgetItems, refresh, loading } = useBudget();
   const navigate = useNavigate();
-
-
-  // Listen for budget updates from BudgetPage via window event
-  useEffect(() => {
-    const handleBudgetUpdated = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { projectId?: string } | undefined;
-      if (detail?.projectId === projectId) {
-        refresh();
-      }
-    };
-    window.addEventListener("budgetUpdated", handleBudgetUpdated as EventListener);
-    return () => window.removeEventListener("budgetUpdated", handleBudgetUpdated as EventListener);
-  }, [projectId, refresh]);
-
-  // Listen for websocket budgetUpdated messages
-  useEffect(() => {
-    const unsubscribe = onSocketEvent((data: any) => {
-      if (data?.action === "budgetUpdated" && data.projectId === projectId) {
-        console.log("[BudgetComponent] budgetUpdated for project", projectId);
-        refresh();
-      }
-    });
-    return unsubscribe;
-  }, [onSocketEvent, activeProject?.projectId, refresh]);
 
   const [groupBy] = useState<"invoiceGroup" | "none">("invoiceGroup");
   const [isInvoicePreviewOpen, setIsInvoicePreviewOpen] = useState(false);

--- a/src/pages/dashboard/components/SingleProject/BudgetDataProvider.tsx
+++ b/src/pages/dashboard/components/SingleProject/BudgetDataProvider.tsx
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, PropsWithChildren, useEffect, useMemo, useRef } from "react";
+import useBudgetData from "./useBudgetData";
+import { useSocketEvents } from "../../../../app/contexts/SocketContext";
+import type { BudgetHeader, BudgetLine } from "../../../../utils/api";
+
+interface BudgetContextValue {
+  budgetHeader: BudgetHeader | null;
+  budgetItems: BudgetLine[];
+  setBudgetHeader: (header: BudgetHeader | ((prev: BudgetHeader | null) => BudgetHeader)) => void;
+  setBudgetItems: (items: BudgetLine[]) => void;
+  refresh: () => Promise<{ header: BudgetHeader | null; items: BudgetLine[] } | null>;
+  loading: boolean;
+}
+
+const BudgetContext = createContext<BudgetContextValue | undefined>(undefined);
+
+export const useBudget = (): BudgetContextValue => {
+  const ctx = useContext(BudgetContext);
+  if (!ctx) throw new Error("useBudget must be used within BudgetProvider");
+  return ctx;
+};
+
+interface ProviderProps extends PropsWithChildren {
+  projectId?: string;
+}
+
+export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children }) => {
+  const { budgetHeader, budgetItems, setBudgetHeader, setBudgetItems, refresh, loading } = useBudgetData(projectId);
+  const onSocketEvent = useSocketEvents();
+  const refreshRef = useRef(refresh);
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  useEffect(() => {
+    const unsubscribe = onSocketEvent((data: any) => {
+      if (data?.action === "budgetUpdated" && data.projectId === projectId) {
+        refreshRef.current();
+      }
+    });
+    const handleWindow = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { projectId?: string } | undefined;
+      if (detail?.projectId === projectId) {
+        refreshRef.current();
+      }
+    };
+    window.addEventListener("budgetUpdated", handleWindow as EventListener);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("budgetUpdated", handleWindow as EventListener);
+    };
+  }, [onSocketEvent, projectId]);
+
+  const value = useMemo(
+    () => ({ budgetHeader, budgetItems, setBudgetHeader, setBudgetItems, refresh, loading }),
+    [budgetHeader, budgetItems, setBudgetHeader, setBudgetItems, refresh, loading]
+  );
+
+  return <BudgetContext.Provider value={value}>{children}</BudgetContext.Provider>;
+};
+
+export default BudgetProvider;
+

--- a/src/pages/dashboard/components/SingleProject/BudgetItemsTable.tsx
+++ b/src/pages/dashboard/components/SingleProject/BudgetItemsTable.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { Table } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import styles from "../../BudgetPage.module.css";
+
+const TABLE_HEADER_FOOTER = 110;
+
+interface BudgetItemsTableProps {
+  dataSource: any[];
+  columns: ColumnsType<any>;
+  groupBy: string;
+  selectedRowKeys: string[];
+  lockedLines: string[];
+  handleTableChange: (pagination: any, filters: any, sorter: any, extra: any) => void;
+  openEditModal: (record: any) => void;
+  openDeleteModal: (ids: string[]) => void;
+  expandedRowRender: (record: any) => React.ReactNode;
+  expandedRowKeys: string[];
+  setExpandedRowKeys: React.Dispatch<React.SetStateAction<string[]>>;
+  tableRef: React.RefObject<HTMLDivElement>;
+  tableHeight: number;
+  pageSize: number;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  setPageSize: (size: number) => void;
+}
+
+const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
+  ({
+    dataSource,
+    columns,
+    groupBy,
+    selectedRowKeys,
+    lockedLines,
+    handleTableChange,
+    openEditModal,
+    openDeleteModal,
+    expandedRowRender,
+    expandedRowKeys,
+    setExpandedRowKeys,
+    tableRef,
+    tableHeight,
+    pageSize,
+    currentPage,
+    setCurrentPage,
+    setPageSize,
+  }) => {
+    return (
+      <div ref={tableRef} style={{ width: "100%", fontSize: "10px" }}>
+        <Table
+          dataSource={dataSource}
+          columns={columns.map((col) => ({
+            ...col,
+            ellipsis: col.key !== "actions" && col.key !== "events",
+          }))}
+          locale={{
+            emptyText: (
+              <div className={styles.emptyPlaceholder}>No budget items to display</div>
+            ),
+          }}
+          onChange={handleTableChange}
+          rowClassName={(record) =>
+            `${styles.clickableRow}${
+              selectedRowKeys.includes(record.budgetItemId)
+                ? ` ${styles.selectedRow}`
+                : ""
+            }${
+              lockedLines.includes(record.budgetItemId)
+                ? ` ${styles.lockedRow}`
+                : ""
+            }`
+          }
+          onRow={(record) => ({
+            onClick: () => openEditModal(record),
+            tabIndex: lockedLines.includes(record.budgetItemId) ? -1 : 0,
+            onKeyDown: (e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                openEditModal(record);
+              } else if (e.key === " ") {
+                e.preventDefault();
+                openDeleteModal([record.budgetItemId]);
+              }
+            },
+          })}
+          expandable={
+            dataSource.length > 0
+              ? {
+                  expandedRowRender,
+                  expandIconColumnIndex: columns.length,
+                  expandedRowOffset: groupBy === "none" ? 1 : 2,
+                  expandedRowKeys,
+                  onExpand: (expanded, record) => {
+                    setExpandedRowKeys((prev) =>
+                      expanded
+                        ? [...prev, record.key]
+                        : prev.filter((k) => k !== record.key)
+                    );
+                  },
+                }
+              : undefined
+          }
+          pagination={{
+            pageSize,
+            current: currentPage,
+            showSizeChanger: true,
+            pageSizeOptions: ["10", "20", "50", "100"],
+            position: ["bottomRight"],
+            showTotal: (total, range) => `Showing ${range[0]}–${range[1]} of ${total} items`,
+            size: "small",
+            onChange: (page, size) => {
+              setCurrentPage(page);
+              if (size !== pageSize) setPageSize(size);
+            },
+          }}
+          scroll={{ y: Math.max(0, tableHeight - TABLE_HEADER_FOOTER) }}
+          className={styles.tableMinHeight}
+          style={{ height: tableHeight }}
+        />
+      </div>
+    );
+  }
+);
+
+export default BudgetItemsTable;
+

--- a/src/pages/dashboard/components/SingleProject/InvoicePreviewModal.tsx
+++ b/src/pages/dashboard/components/SingleProject/InvoicePreviewModal.tsx
@@ -32,7 +32,7 @@ import ConfirmModal from "../../../../components/ConfirmModal";
 import { toast } from "react-toastify";
 import styles from "./InvoicePreviewModal.module.css";
 import useModalStack from "../../../../utils/useModalStack";
-import useBudgetData from "./useBudgetData";
+import { useBudget } from "./BudgetDataProvider";
 
 // ---------- Types ----------
 interface RevisionLike {
@@ -125,7 +125,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
   const [groupField, setGroupField] = useState<GroupField>("invoiceGroup");
   const [groupValues, setGroupValues] = useState<string[]>([]);
   const { userData, setUserData } = useData();
-  const { budgetItems } = useBudgetData(project?.projectId);
+  const { budgetItems } = useBudget();
 
   // layout/refs
   const invoiceRef = useRef<HTMLDivElement | null>(null);

--- a/src/pages/dashboard/components/SingleProject/ProjectCalendar.tsx
+++ b/src/pages/dashboard/components/SingleProject/ProjectCalendar.tsx
@@ -26,7 +26,7 @@ import {
   faClock,
 } from "@fortawesome/free-solid-svg-icons";
 import { enqueueProjectUpdate } from "../../../../utils/requestQueue";
-import useBudgetData from "./useBudgetData";
+import { useBudget } from "./BudgetDataProvider";
 
 type TimelineEvent = {
   id: string;
@@ -204,9 +204,7 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
   const calendarWrapperRef = useRef<HTMLDivElement | null>(null);
   const ignoreNextWrapperClickRef = useRef(false);
 
-  const { budgetHeader, budgetItems, setBudgetItems } = useBudgetData(
-    project?.projectId
-  );
+  const { budgetHeader, budgetItems, setBudgetItems } = useBudget();
 
   const [flashDate, setFlashDate] = useState<Date | null>(
     initialFlashDate ? safeParse(initialFlashDate) : null

--- a/src/pages/dashboard/components/SingleProject/TasksComponent.test.tsx
+++ b/src/pages/dashboard/components/SingleProject/TasksComponent.test.tsx
@@ -14,10 +14,10 @@ jest.mock('../../../../utils/api', () => ({
   fetchUserProfilesBatch: jest.fn(() => Promise.resolve([]))
 }));
 
-const mockUseBudgetData = jest.fn(() => ({ budgetItems: [] }));
-jest.mock('./useBudgetData', () => ({
+const mockUseBudget = jest.fn(() => ({ budgetItems: [] }));
+jest.mock('./BudgetDataProvider', () => ({
   __esModule: true,
-  default: (...args: any[]) => mockUseBudgetData(...args)
+  useBudget: (...args: any[]) => mockUseBudget(...args)
 }));
 
 beforeAll(() => {
@@ -38,7 +38,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  mockUseBudgetData.mockReturnValue({ budgetItems: [] });
+  mockUseBudget.mockReturnValue({ budgetItems: [] });
   (fetchTasks as jest.Mock).mockResolvedValue([]);
   (fetchTasks as jest.Mock).mockClear();
 

--- a/src/pages/dashboard/components/SingleProject/TasksComponent.tsx
+++ b/src/pages/dashboard/components/SingleProject/TasksComponent.tsx
@@ -34,7 +34,7 @@ import {
   deleteTask,
   fetchUserProfilesBatch,
 } from "../../../../utils/api";
-import useBudgetData from "./useBudgetData";
+import { useBudget } from "./BudgetDataProvider";
 import "../../components/SingleProject/tasks-table.css";
 
 /* =========================
@@ -235,7 +235,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
     editForm.setFieldsValue({ location: loc, address: s.display_name });
   };
 
-  const { budgetItems } = useBudgetData(projectId);
+  const { budgetItems } = useBudget();
   const [teamProfiles, setTeamProfiles] = useState<TeamMember[]>([]);
 
   // Fetch user profiles for team userIds

--- a/src/pages/dashboard/components/SingleProject/__tests__/BudgetComponent.test.tsx
+++ b/src/pages/dashboard/components/SingleProject/__tests__/BudgetComponent.test.tsx
@@ -18,10 +18,10 @@ jest.mock("../../../../utils/api", () => ({
   fetchUserProfilesBatch: jest.fn(() => Promise.resolve([])),
 }));
 
-const mockUseBudgetData = jest.fn(() => ({ budgetItems: [] }));
-jest.mock("./useBudgetData", () => ({
+const mockUseBudget = jest.fn(() => ({ budgetItems: [] }));
+jest.mock("../BudgetDataProvider", () => ({
   __esModule: true,
-  default: (...args: any[]) => mockUseBudgetData(...args),
+  useBudget: (...args: any[]) => mockUseBudget(...args),
 }));
 
 beforeAll(() => {
@@ -42,7 +42,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  mockUseBudgetData.mockReturnValue({ budgetItems: [] });
+  mockUseBudget.mockReturnValue({ budgetItems: [] });
 
   (fetchTasks as jest.Mock).mockResolvedValue([]);
   (fetchTasks as jest.Mock).mockClear();


### PR DESCRIPTION
## Summary
- add BudgetProvider and share budget data via context
- wrap SingleProject dashboard sections with BudgetProvider
- extract budget items table into dedicated component to reduce re-renders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab67128874832482233829aa4ccd8e